### PR TITLE
Unspecified coding task

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -492,7 +492,7 @@ fn print_top_for_metric<F>(
     if with_values.is_empty() {
         return;
     }
-    with_values.sort_by(|a, b| b.0.cmp(&a.0));
+    with_values.sort_by_key(|b| std::cmp::Reverse(b.0));
     println!("{metric_id}  ({display_name})  top {n}");
     println!("{:>5}  {:<40}  {:>5}  name", "value", "file", "line");
     println!("{}", "-".repeat(70));


### PR DESCRIPTION
Fix clippy lint and restore Git LFS test files to pass pre-commit checks.

The clippy lint in `src/main.rs` was updated from `sort_by` to `sort_by_key` for idiomatic Rust. The Git LFS test fixture files in `tests/fake_python/` were not correctly fetched, leading to test failures, and were manually restored.

---
<a href="https://cursor.com/background-agent?bcId=bc-8f84a32a-9fa0-4ab7-96aa-a17f20759cb4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8f84a32a-9fa0-4ab7-96aa-a17f20759cb4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

